### PR TITLE
Time extension - update for number of time samples > 1

### DIFF
--- a/bsi_zoo/estimators.py
+++ b/bsi_zoo/estimators.py
@@ -15,6 +15,7 @@ def _solve_lasso(Lw, y, alpha, max_iter):
             max_iter=max_iter, normalize=False, fit_intercept=False, alpha=alpha
         )
         x = model.fit(Lw, y).coef_.copy()
+        x = x.T
     else:
         model = linear_model.MultiTaskLasso(
             max_iter=max_iter, normalize=False, fit_intercept=False, alpha=alpha

--- a/bsi_zoo/tests/test_estimators.py
+++ b/bsi_zoo/tests/test_estimators.py
@@ -51,7 +51,7 @@ def _generate_data(n_sensors, n_times, n_sources, nnz):
 #     np.testing.assert_allclose(x, x_hat, rtol=rtol, atol=atol)
 
 def test_estimator(solver, alpha, rtol, atol, cov_type):
-    y, L, x, cov = _generate_data(n_sensors=50, n_times=20, n_sources=200, nnz=1)
+    y, L, x, cov = _generate_data(n_sensors=50, n_times=10, n_sources=200, nnz=1)
     if cov_type == 'diag':
         whitener = linalg.inv(linalg.sqrtm(cov))
         L = whitener @ L


### PR DESCRIPTION
Hi, @agramfort Here are the latest updates of the code for extending the methods to cover a different number of time samples. 

the master branch works for n_samples = 1 
this branch seems to work for n_samples > 1 

Apparently, one of methods, i.e. iterative_L2_typeII failed due to the AssertionError. 
And please also note that if we again move back to the single sample case by replacing y with y[:,0] all these tests are going to fail. This also happens in MNE Gamma-map and MxNE functions as well. 
I am not sure how can I improve the current version further. So, your feedback would be appreciated. 
