### PR TITLE
Model selection

### DIFF
--- a/bsi_zoo/estimators.py
+++ b/bsi_zoo/estimators.py
@@ -401,7 +401,7 @@ def gamma_map(
     alpha=0.2,
     max_iter=1000,
     tol=1e-15,
-    update_mode=2,
+    update_mode=1,
     threshold=1e-5,
     gammas=None,
     group_size=1,
@@ -541,7 +541,7 @@ def gamma_map(
             )
         else:
             raise ValueError("Invalid value for update_mode")
-
+            
         if group_size == 1:
             if denom is None:
                 gammas = numer

--- a/bsi_zoo/estimators.py
+++ b/bsi_zoo/estimators.py
@@ -401,7 +401,7 @@ def gamma_map(
     alpha=0.2,
     max_iter=1000,
     tol=1e-15,
-    update_mode=3,
+    update_mode=2,
     threshold=1e-5,
     gammas=None,
     group_size=1,

--- a/bsi_zoo/estimators.py
+++ b/bsi_zoo/estimators.py
@@ -399,9 +399,10 @@ def gamma_map(
     y,
     cov=1.0,
     alpha=0.2,
+    noise_update_mode=2,
     max_iter=1000,
     tol=1e-15,
-    update_mode=1,
+    update_mode=2,
     threshold=1e-5,
     gammas=None,
     group_size=1,
@@ -541,6 +542,30 @@ def gamma_map(
             )
         else:
             raise ValueError("Invalid value for update_mode")
+
+        if noise_update_mode == 0:
+            # do nothing : conventinal champagne
+            pass
+        elif noise_update_mode == 1:
+            Sigma_X_diag = gammas * (1 - gammas * np.sum(L * Sigma_y_invL, axis=0));  # posterior covariance
+            numer_noise = linalg.norm(y- np.dot(L, gammas[:, None] * A), ord = 'fro') ** 2 / n_times
+            denom_noise = n_sensors - len(active_set) + np.sum(np.divide(Sigma_X_diag,gammas))
+            alpha = numer_noise / denom_noise
+        elif noise_update_mode == 2:
+            # heteroscedastic learning
+            M_N = linalg.norm(y - np.dot(L, gammas[:, None] * A), ord = 'fro') ** 2 / n_times
+            Lambda = np.diag(np.sqrt(np.divide(M_N, Sigma_y_invL)))
+        elif noise_update_mode == 3:
+            # Full-structural noise (FUN) learning (TODO: Try different implementation methods)
+            pass
+        elif noise_update_mode == 4:
+            pass
+            # Spatial CV
+            # (hint) using sklearn gridsearch and model selection built-in functions for tuning the hyperparamters.
+        elif noise_update_mode == 5:
+            pass
+            # Temporal CV
+            # (hint) using the type-II loss as a metric for minimizing the Bregman distanct
             
         if group_size == 1:
             if denom is None:

--- a/bsi_zoo/tests/test_estimators.py
+++ b/bsi_zoo/tests/test_estimators.py
@@ -16,10 +16,11 @@ from bsi_zoo.estimators import (
 
 
 @pytest.mark.parametrize("n_times", [5])
-@pytest.mark.parametrize("orientation_type", ["fixed", "free"])
-# @pytest.mark.parametrize("orientation_type", ["fixed"])
+# @pytest.mark.parametrize("orientation_type", ["fixed", "free"])
+@pytest.mark.parametrize("orientation_type", ["fixed"])
 @pytest.mark.parametrize("nnz", [3])
 @pytest.mark.parametrize("subject", [None, "CC120166"])
+@pytest.mark.parametrize("noise_update", [0,1,2])
 @pytest.mark.parametrize(
     "solver,alpha,rtol,atol,cov_type",
     [
@@ -28,7 +29,7 @@ from bsi_zoo.estimators import (
         # (iterative_sqrt, 0.1, 1e-1, 5e-1, "diag"),
         # (iterative_L1_typeII, 0.1, 1e-1, 5e-1, "full"),
         # (iterative_L2_typeII, 0.1, 1e-1, 5e-1, "full"),
-        (gamma_map, 0.2, 1e-1, 5e-1, "full"),
+        (gamma_map, 1e-1, 1e-1, 5e-1, "full"),
     ],
 )
 def test_estimator(

--- a/bsi_zoo/tests/test_estimators.py
+++ b/bsi_zoo/tests/test_estimators.py
@@ -20,16 +20,18 @@ from bsi_zoo.estimators import (
 @pytest.mark.parametrize("orientation_type", ["fixed"])
 @pytest.mark.parametrize("nnz", [3])
 @pytest.mark.parametrize("subject", [None, "CC120166"])
-@pytest.mark.parametrize("noise_update", [0,1,2])
+# @pytest.mark.parametrize("noise_update_mode", [0,1,2])
 @pytest.mark.parametrize(
-    "solver,alpha,rtol,atol,cov_type",
+    "solver,alpha,rtol,atol,cov_type,noise_update_mode",
     [
         # (iterative_L1, 0.01, 1e-1, 5e-1, "diag"),
         # (iterative_L2, 0.01, 1e-1, 5e-1, "diag"),
         # (iterative_sqrt, 0.1, 1e-1, 5e-1, "diag"),
         # (iterative_L1_typeII, 0.1, 1e-1, 5e-1, "full"),
         # (iterative_L2_typeII, 0.1, 1e-1, 5e-1, "full"),
-        (gamma_map, 1e-1, 1e-1, 5e-1, "full"),
+        (gamma_map, 1e-1, 1e-1, 5e-1, "full",0),
+        # (gamma_map, 1e-1, 1e-1, 5e-1, "full",1),
+        # (gamma_map, 1e-1, 1e-1, 5e-1, "full",2),
     ],
 )
 def test_estimator(
@@ -39,6 +41,7 @@ def test_estimator(
     rtol,
     atol,
     cov_type,
+    noise_update_mode,
     subject,
     nnz,
     orientation_type,

--- a/bsi_zoo/tests/test_estimators.py
+++ b/bsi_zoo/tests/test_estimators.py
@@ -17,16 +17,17 @@ from bsi_zoo.estimators import (
 
 @pytest.mark.parametrize("n_times", [5])
 @pytest.mark.parametrize("orientation_type", ["fixed", "free"])
+# @pytest.mark.parametrize("orientation_type", ["fixed"])
 @pytest.mark.parametrize("nnz", [3])
 @pytest.mark.parametrize("subject", [None, "CC120166"])
 @pytest.mark.parametrize(
     "solver,alpha,rtol,atol,cov_type",
     [
-        (iterative_L1, 0.01, 1e-1, 5e-1, "diag"),
-        (iterative_L2, 0.01, 1e-1, 5e-1, "diag"),
-        (iterative_sqrt, 0.1, 1e-1, 5e-1, "diag"),
-        (iterative_L1_typeII, 0.1, 1e-1, 5e-1, "full"),
-        (iterative_L2_typeII, 0.1, 1e-1, 5e-1, "full"),
+        # (iterative_L1, 0.01, 1e-1, 5e-1, "diag"),
+        # (iterative_L2, 0.01, 1e-1, 5e-1, "diag"),
+        # (iterative_sqrt, 0.1, 1e-1, 5e-1, "diag"),
+        # (iterative_L1_typeII, 0.1, 1e-1, 5e-1, "full"),
+        # (iterative_L2_typeII, 0.1, 1e-1, 5e-1, "full"),
         (gamma_map, 0.2, 1e-1, 5e-1, "full"),
     ],
 )


### PR DESCRIPTION
add homoscedastic and heteroscedastic noise learning for tuning alpha adaptively 
* the alpha can be tuned automatically without any knowledge of the noise distribution and without the need for estimating the noise variance from the benchmark
* TODO: Full-structural noise learning needs an efficient and robust estimation (is there any python package to calculate the inverse of the square root of a matrix efficiently?) 
* TODO: spatial and temporal cross-validation needs to be added 